### PR TITLE
Fix profile page erroring out for users with multiple spaces in their username

### DIFF
--- a/apps/api/app/models/user.ts
+++ b/apps/api/app/models/user.ts
@@ -440,7 +440,7 @@ schema.static("findByUrl", function (this: UserModel, urlComponent: string) {
 });
 
 schema.static("findByUsername", function (this: UserModel, username: string) {
-  return this.findOne({ "security.slug": username.toLowerCase().replace(/\s+/, "-") });
+  return this.findOne({ "security.slug": username.toLowerCase().replace(/\s+/g, "-") });
 });
 
 schema.static("findByEmail", function (this: UserModel, email: string) {


### PR DESCRIPTION
This was caused by `findByUsername` only replacing the first match of spaces with a hyphen. Updated to global