### PR TITLE
Implement multi-instance support with unique loopback IP allocation

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -13,6 +13,6 @@ jobs:
       - run: pnpm install
       # oxfmt formats JS/TS/YAML/MD/JSON across the repo (Svelte excluded — oxfmt's
       # Svelte parser is still beta). Svelte files are checked by prettier.
-      - run: npx oxfmt --check .
+      - run: pnpm run format-check
       - run: cd apps/admin && npx prettier --check "src/**/*.svelte"
       - run: cd apps/web && npx prettier --check "src/**/*.svelte"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pnpm-debug.log*
 .pnpm-store
 .fast-check
 .playwright-mcp
+.worktrees

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Division of labor:
 
   ```bash
   IP=$(scripts/instance-ip.sh alloc <name>)       # unique 127.1.X.Y, idempotent
-	[spawn subagent with IP, tell it its name]
+    [spawn subagent with IP, tell it its name]
   for app in api game-server; do
     [ -f apps/$app/.env ] && cp apps/$app/.env .worktrees/<name>/apps/$app/.env
   done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,51 @@ Default to no comment — write self-explanatory code. Only comment the non-obvi
 
 Avoid reading env vars & secrets directly, you can store them in files or env and load them, but avoid reading them directly
 
+## Running instances (agent swarms)
+
+Multiple copies of the stack can run side-by-side on one machine — this is how a
+coordinator agent gives each of its sub-agents an isolated environment.
+**Never run two agents against the default ports/db at once** (they collide and
+share `bgs-dev`).
+
+Division of labor:
+
+- **Coordinator**: spawns one sub-agent per worktree. Before spawning, pick a
+  unique `<name>`, allocate its IP, and **copy the local env files into the
+  worktree** — `.env` is gitignored so the worktree has none:
+
+  ```bash
+  IP=$(scripts/instance-ip.sh alloc <name>)       # unique 127.1.X.Y, idempotent
+	[spawn subagent with IP, tell it its name]
+  for app in api game-server; do
+    [ -f apps/$app/.env ] && cp apps/$app/.env .worktrees/<name>/apps/$app/.env
+  done
+  # (no .env on this machine? give the sub-agent a dbUrl in its task instead)
+  ```
+
+- **Sub-agent**: runs the stack from inside its worktree, on the IP it was given:
+
+  ```bash
+  pnpm install
+  listenHost=$IP dbName=bgs-<name> \
+    VITE_backend=$IP WEB_HOST=$IP \
+    pnpm dev                                        # web+api+game-server, default ports
+  # → http://<IP>:8612   (api 50801, ws 50802, game-server 50803, all on the IP)
+  # when done: coordinator runs scripts/instance-ip.sh free <name>
+  ```
+
+Rules for the agent:
+
+- Always set `dbName` (e.g. `bgs-<name>`) — otherwise the instance shares the
+  default `bgs-dev` db. `NODE_ENV` stays unset (development), so the db is
+  actually `bgs-<name>-dev` and apps never fork `threads=cpu` workers.
+- **Don't set `dbUrl` if the coordinator gave you an `.env`** — it already
+  points at the right Mongo for this host, and `dbUrl` overrides it. If there
+  is **no** `apps/api/.env` in your worktree, set `dbUrl` explicitly if the default
+  one doesnt work (ask the
+  coordinator for the Mongo URL if you don't have one). Mongo must be running
+  (`docker compose up -d mongo` → port 27517, or whatever the local `.env` says).
+
 ## Workarounds
 
 Each project keeps a `WORKAROUNDS.md` (e.g. `apps/web/WORKAROUNDS.md`, `apps/api/WORKAROUNDS.md`) listing temporary shims and deferred cleanups — things intentional for now but to revisit later. When you add such a thing, log a short entry there; when you touch related code, check whether an entry can be removed.

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ pnpm dev
 
 Add `pnpm dev:admin` for the admin panel.
 
-## Contributing
+### Multiple isolated instances
 
-We welcome contributions from everybody! Don't hesitate to ask a question.
+To run several copies of the stack side-by-side (e.g. one per agent or per PR),
+give each its own worktree and loopback IP.
 
-VS Code is the recommended editor. Its workspace feature is great to open multiple windows, one with all the back, and another with the all the front.
-Install the prettier & [gitmoji](https://github.com/carloscuesta/gitmoji) extensions!
+See the "Running instances" section of [AGENTS.md](./AGENTS.md) for details.

--- a/apps/api/WORKAROUNDS.md
+++ b/apps/api/WORKAROUNDS.md
@@ -2,15 +2,9 @@
 
 Things that are intentional for now but should be revisited / removed later. Add an entry when you leave a temporary shim, a deferred migration, or anything a future reader might mistake for a permanent decision. Keep entries short and link the code.
 
-## Dev/prod listen host defaults to `127.0.0.1` (`app/config/env.ts`)
+## Listen host: default `127.0.0.1`, prod binds `::1` (`app/config/env.ts`)
 
-`env.listen.host` defaults to `127.0.0.1` (was `localhost`). On hosts whose `/etc/hosts` maps `localhost` to **both** `127.0.0.1` and `::1`, Node's `http.listen("localhost")` binds **only `::1`**. The dev Vite proxy (`apps/admin/vite.config.ts`) dials `127.0.0.1`, so it was refused. Standardising on `127.0.0.1` everywhere (server bind + proxy targets) matches the repo's existing convention — `app/config/test-setup.ts` already forces `127.0.0.1`, the Loki route uses `127.0.0.1:3100`, and the bundled nginx sample (`app/config/nginx`) uses `127.0.0.1`.
-
-**Prod note (2026-07-10):** prod nginx upstreams (`/etc/nginx/sites-enabled/gaia-project`) now dial `127.0.0.1` for api 50801 / ws 50802 / gameplay 50803 / resources 50804 — matching this default. Both sides are aligned; no `listenHost` env override is needed in prod. Don't change the default back to `localhost` or flip nginx to `::1` without doing both simultaneously (see the rationale above — `localhost` binds only `::1` on this host, so an IPv4 nginx dial is refused). Operators can still force `::1` / `0.0.0.0` via `listenHost`. Game-server (`apps/game-server/app/config/env.ts`) mirrors this. Revisit if we ever move to dual-stack listen or a hostname-based upstream.
-
-## Migration-order CI guard supports the old layout (`scripts/check-migrations.ts`)
-
-`check-migrations.ts` reads the base branch's migration registry across **both** the old single-file (`migrations.ts`) and new per-version (`migrations/`) layouts, because the refactor straddles that change. Once the new layout is on `main`, the old-layout fallback (`baseSource()`'s second candidate path) can be dropped.
+`env.listen.host` defaults to `127.0.0.1` (local dev, `scripts/instance-ip.sh` multi-instance). Prod is full IPv6: `listenHost=::1` in the prod env, and the nginx upstreams dial `::1`. Override via the `listenHost` env var. One rule: server bind and whoever dials it (nginx, vite proxy) must use the **same address family** — on coyo `localhost` binds only `::1`, so an IPv4 dial is refused (and vice versa). Revisit if we move to dual-stack listen or a hostname-based upstream. Game-server (`apps/game-server/app/config/env.ts`) mirrors this.
 
 ## Koa doesn't recognise web streams or BSON `Binary` as response bodies (`app/routes/user/index.ts`)
 

--- a/apps/api/scripts/check-migrations.ts
+++ b/apps/api/scripts/check-migrations.ts
@@ -7,9 +7,8 @@
  * migration keyed at or below an existing one would silently never run.
  *
  * Compares the migration registry on the current checkout against the base ref
- * (default `origin/main`, override with $BASE_REF). Works across both the old
- * single-file (`migrations.ts`) and the new per-version (`migrations/`) layouts,
- * since it just scrapes the `"x.y.z":` registry keys from whichever exists.
+ * (default `origin/main`, override with $BASE_REF) by scraping the `"x.y.z":`
+ * registry keys from `migrations/index.ts`.
  */
 import { execFileSync } from "node:child_process";
 import semver from "semver";
@@ -24,19 +23,14 @@ function keysFromSource(source: string): string[] {
 }
 
 function baseSource(): string | null {
-	// The base branch may keep migrations in either layout; try both.
-	const candidates = ["apps/api/app/models/migrations/index.ts", "apps/api/app/models/migrations.ts"];
-	for (const path of candidates) {
-		try {
-			return execFileSync("git", ["show", `${BASE_REF}:${path}`], {
-				encoding: "utf8",
-				stdio: ["ignore", "pipe", "ignore"],
-			});
-		} catch {
-			// not present at this path on the base ref; try the next
-		}
+	try {
+		return execFileSync("git", ["show", `${BASE_REF}:apps/api/app/models/migrations/index.ts`], {
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+		});
+	} catch {
+		return null;
 	}
-	return null;
 }
 
 function main() {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -14,11 +14,11 @@
 		"@vuepress/plugin-medium-zoom": "^1.3.1",
 		"vuepress": "^1.3.1"
 	},
+	"lint-staged": {
+		"*": "oxfmt --ignore-unknown"
+	},
 	"authors": {
 		"name": "coyotte508",
 		"email": "coyotte508@gmail.com"
-	},
-	"lint-staged": {
-		"*": "oxfmt --ignore-unknown"
 	}
 }

--- a/apps/game-server/WORKAROUNDS.md
+++ b/apps/game-server/WORKAROUNDS.md
@@ -2,8 +2,6 @@
 
 Things that are intentional for now but should be revisited / removed later. Add an entry when you leave a temporary shim, a deferred migration, or anything a future reader might mistake for a permanent decision. Keep entries short and link the code.
 
-## Dev/prod listen host defaults to `127.0.0.1` (`app/config/env.ts`)
+## Listen host: default `127.0.0.1`, prod binds `::1` (`app/config/env.ts`)
 
-`env.listen.host` defaults to `127.0.0.1` (was `localhost`). Same rationale as `apps/api/app/config/env.ts` — on hosts whose `/etc/hosts` maps `localhost` to **both** `127.0.0.1` and `::1`, Node's `http.listen("localhost")` binds **only `::1`**, while nginx (prod) dials `127.0.0.1` → `ECONNREFUSED`.
-
-**Prod note (2026-07-10):** prod nginx upstream (`/etc/nginx/sites-enabled/gaia-project`, `gaia_game_server`) now dials `127.0.0.1:50803` — matching this default. Both sides are aligned; no `listenHost` env override is needed in prod. Operators can still force `::1` / `0.0.0.0` via `listenHost`. See `apps/api/WORKAROUNDS.md` for the full history. Revisit if we ever move to dual-stack listen or a hostname-based upstream.
+Same as `apps/api` (`apps/api/WORKAROUNDS.md`): `env.listen.host` defaults to `127.0.0.1` for local dev / multi-instance (`scripts/instance-ip.sh`); prod sets `listenHost=::1` and the nginx upstream (`gaia_game_server`) dials `::1:50803`. Override via the `listenHost` env var; keep server bind and the nginx upstream on the same address family.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"start": "node build/index.js",
-		"dev": "vite dev --port 8612 --host",
+		"dev": "vite dev --strictPort --port ${WEB_PORT:-8612} --host ${WEB_HOST:-127.0.0.1}",
 		"build": "vite build",
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --tsgo",

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -61,6 +61,13 @@ export const handle: Handle = async ({ event, resolve }) => {
 	});
 };
 
+function backendUrl(override: string | undefined, defaultPort: number): string {
+	const raw = (override ?? import.meta.env.VITE_backend ?? "127.0.0.1").replace(/^https?:\/\//, "");
+	const [host, port] = raw.split(":");
+	const ip = host.includes(":") ? `[${host}]` : host; // bare IPv6
+	return `http://${ip}:${port ?? defaultPort}`;
+}
+
 /**
  * During SSR, event.fetch calls are routed through here. We rewrite /api/*
  * URLs to the backend host (same logic as the old externalFetch hook, minus the
@@ -72,11 +79,17 @@ export const handleFetch: HandleFetch = async ({ request, fetch, event }) => {
 
 	const isGameplay = path.startsWith("/api/gameplay");
 	const isMainApi = !isGameplay && path.startsWith("/api/");
-	// Backend loopback host — 127.0.0.1 in local dev (vite), ::1 in prod (matches nginx).
-	// Ports are fixed per service; only the host family varies by environment.
-	const host = import.meta.env.VITE_backend_host ?? "127.0.0.1";
-	const backendHost = host.includes(":") ? `[${host}]` : host;
-	const backend = isGameplay ? `http://${backendHost}:50803` : isMainApi ? `http://${backendHost}:50801` : null;
+
+	// Backend address: `VITE_backend` (host or host:port — same var as vite.config.ts)
+	// locates the api service; the gameplay backend defaults to the same host on its
+	// standard port so multi-instance dev (one loopback IP per instance, default ports
+	// — see AGENTS.md "Running instances") only has to set the one variable.
+	// Per-service escape hatches: VITE_backend_api / VITE_backend_gameplay.
+	const backend = isGameplay
+		? backendUrl(import.meta.env.VITE_backend_gameplay, 50803)
+		: isMainApi
+			? backendUrl(import.meta.env.VITE_backend_api, 50801)
+			: null;
 
 	if (backend) {
 		request = new Request(request.url.replace(event.url.origin, backend), request);

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,9 +3,24 @@ import { sveltekit } from "@sveltejs/kit/vite";
 import { defineConfig } from "vite";
 import { execSync } from "node:child_process";
 
-const backend = process.env.VITE_backend ?? "http://127.0.0.1:50801";
-const gameplayBackend = process.env.VITE_backend ?? "http://127.0.0.1:50803";
-const resourcesBackend = (process.env.VITE_backend ?? "http://127.0.0.1:50804").replace("www.", "resources.");
+// VITE_backend locates the api service; the gameplay/ws/resources backends default to
+// the same host on their standard ports, so multi-instance dev (one loopback IP per
+// instance, default ports — see AGENTS.md "Running instances") only sets the one
+// variable. Per-service escape hatches: VITE_backend_api / VITE_backend_gameplay /
+// VITE_backend_ws / VITE_backend_resources (each host or host:port).
+// Proxy targets always need explicit ports.
+const withPort = (hostPort: string, port: number) => {
+	const [host, p] = hostPort.replace(/^https?:\/\//, "").split(":");
+	return `http://${host.includes(":") ? `[${host}]` : host}:${p ?? port}`;
+};
+
+const backend = withPort(process.env.VITE_backend_api ?? process.env.VITE_backend ?? "127.0.0.1", 50801);
+const gameplayBackend = withPort(process.env.VITE_backend_gameplay ?? process.env.VITE_backend ?? "127.0.0.1", 50803);
+const wsBackend = withPort(process.env.VITE_backend_ws ?? process.env.VITE_backend ?? "127.0.0.1", 50802);
+const resourcesBackend = withPort(
+	process.env.VITE_backend_resources ?? process.env.VITE_backend ?? "127.0.0.1",
+	50804,
+).replace("www.", "resources.");
 
 // Stamp a release id (git SHA, else package version) into the client bundle so error
 // reports can be tied to a specific build — invaluable during a migration.
@@ -28,7 +43,7 @@ export default defineConfig({
 		port: 8612,
 		proxy: {
 			"/ws": {
-				target: process.env.VITE_backend ?? "http://127.0.0.1:50802",
+				target: wsBackend,
 				changeOrigin: true,
 				ws: true,
 			},

--- a/infra/README.md
+++ b/infra/README.md
@@ -17,11 +17,12 @@ PM2 is managed as the `bgs` user (not root). Logs are in `~/.pm2/logs/`.
 
 ## Nginx
 
-Nginx (root) fronts all public traffic:
+Nginx (root) fronts all public traffic. Prod is **full IPv6**: app processes bind
+`::1` (`listenHost=::1` in the prod env) and nginx upstreams dial `::1`:
 
-- `boardgamers.space` / `www.boardgamers.space` → SvelteKit SSR (`127.0.0.1:8612`)
-- `admin.boardgamers.space` → admin SPA (static files + `/api` proxy to `127.0.0.1:50801`)
-- `resources.boardgamers.space` → resources API (`127.0.0.1:50804`)
+- `boardgamers.space` / `www.boardgamers.space` → SvelteKit SSR (`[::1]:8612`)
+- `admin.boardgamers.space` → admin SPA (static files + `/api` proxy to `[::1]:50801`)
+- `resources.boardgamers.space` → resources API (`[::1]:50804`)
 - `forum.boardgamers.space` → NodeBB
 - `grafana.boardgamers.space` → Grafana (`127.0.0.1:3030`)
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
 	"scripts": {
 		"dev": "pnpm --filter @bgs/api --filter game --filter @bgs/web run --parallel dev",
 		"dev:admin": "pnpm --filter @bgs/admin run dev",
-		"fmt": "oxfmt .",
-		"fmt-check": "oxfmt --check ."
+		"format": "oxfmt .",
+		"format-check": "oxfmt --check ."
 	},
 	"devDependencies": {
 		"@typescript/native-preview": "7.0.0-dev.20260707.2",

--- a/scripts/instance-ip.sh
+++ b/scripts/instance-ip.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# instance-ip.sh — allocate a unique loopback IP for an isolated stack instance.
+#
+# Part of the multi-instance setup (see AGENTS.md "Running instances"): the
+# coordinator gives each agent its own checkout under .worktrees/<name>/, and
+# this script hands the agent a unique 127.1.X.Y IP (the whole 127.0.0.0/8
+# block routes on Linux, no setup needed) so every instance can bind the
+# DEFAULT ports (web 8612, api 50801, ws 50802, game-server 50803) on its own
+# IP — no port arithmetic, no collisions.
+#
+# IPs are allocated from a machine-wide registry so two agents never get the
+# same one, regardless of which checkout they run in. Allocation is
+# file-locked and atomic.
+#
+# Usage:
+#   scripts/instance-ip.sh alloc <name>   # → prints the IP (idempotent per name)
+#   scripts/instance-ip.sh free <name>    # release the name's IP
+#   scripts/instance-ip.sh list           # all allocations
+#
+# Env override: BGS_IP_REGISTRY (default ~/.bgs-instances/ips).
+set -euo pipefail
+
+REGISTRY="${BGS_IP_REGISTRY:-$HOME/.bgs-instances/ips}"
+mkdir -p "$(dirname "$REGISTRY")"
+touch "$REGISTRY"
+
+die() { echo "instance-ip.sh: $*" >&2; exit 1; }
+
+valid_name() { [[ "$1" =~ ^[a-z0-9][a-z0-9-]{0,23}$ ]] || die "invalid name '$1' (use [a-z0-9-], max 24 chars)"; }
+
+# All commands funnel through one flock so concurrent agents can't race.
+with_lock() {
+	(
+		flock -x 9
+		"$@"
+	) 9>"$REGISTRY.lock"
+}
+
+lookup() { awk -v n="$1" '$1 == n {print $2}' "$REGISTRY"; }
+
+cmd_alloc() {
+	local name="${1:?usage: instance-ip.sh alloc <name>}"
+	valid_name "$name"
+	with_lock _alloc "$name"
+}
+_alloc() {
+	local name="$1" existing
+	existing=$(lookup "$name")
+	if [[ -n "$existing" ]]; then
+		echo "$existing" # idempotent: same name always gets the same IP
+		return
+	fi
+	# First free 127.1.X.Y: X in 2..254, Y in 2..254 (skip .0/.1/.255 and the
+	# 127.1.1.x range — cheap insurance against anything else using low IPs).
+	local x y ip
+	for x in $(seq 2 254); do
+		for y in $(seq 2 254); do
+			ip="127.1.$x.$y"
+			grep -q " $ip\$" "$REGISTRY" || { echo "$name $ip" >> "$REGISTRY"; echo "$ip"; return; }
+		done
+	done
+	die "no free IPs in 127.1.0.0/16 (registry: $REGISTRY)"
+}
+
+cmd_free() {
+	local name="${1:?usage: instance-ip.sh free <name>}"
+	valid_name "$name"
+	with_lock _free "$name"
+}
+_free() {
+	local name="$1"
+	grep -v "^$name " "$REGISTRY" > "$REGISTRY.tmp" || true
+	mv "$REGISTRY.tmp" "$REGISTRY"
+}
+
+cmd_list() {
+	if [[ -s "$REGISTRY" ]]; then
+		awk '{printf "%-24s %s\n", $1, $2}' "$REGISTRY"
+	else
+		echo "no allocations (registry: $REGISTRY)"
+	fi
+}
+
+case "${1:-}" in
+	alloc) shift; cmd_alloc "$@" ;;
+	free) shift; cmd_free "$@" ;;
+	list) cmd_list ;;
+	*) cat <<-EOF
+		usage: scripts/instance-ip.sh <command>
+
+		  alloc <name>   allocate (idempotently) a unique 127.1.X.Y loopback IP for <name>
+		  free <name>    release the IP allocated to <name>
+		  list           show all allocations (registry: $REGISTRY)
+		EOF
+		exit 1 ;;
+esac


### PR DESCRIPTION
First part of #95 — run multiple isolated copies of the stack side-by-side on one machine.

## What this adds

- **`scripts/instance-ip.sh`** — machine-wide, file-locked allocator for unique loopback IPs (`alloc`/`free`/`list`, idempotent per name, registry at `~/.bgs-instances/ips`). Each instance binds the **default ports** on its own `127.1.X.Y` (the whole `127.0.0.0/8` routes on Linux) — no port arithmetic, no collisions, prod untouched.
- **Agent-swarm contract in `AGENTS.md`** — coordinator spawns one sub-agent per `.worktrees/<name>/`, allocates the IP + copies `.env` files in beforehand, and hands the sub-agent its IP; the sub-agent just `pnpm install` + `pnpm dev` with `listenHost`/`dbName`/`VITE_backend`/`WEB_HOST`.
- **`apps/web` backend discovery via `VITE_backend`** (host or host:port) instead of hardcoded `127.0.0.1:5080x` — one variable locates api/game-server/ws/resources on a same-host instance, with per-service overrides (`VITE_backend_api|_gameplay|_ws|_resources`) in `vite.config.ts` and `hooks.server.ts`. `dev` also honors `WEB_PORT`/`WEB_HOST` + `--strictPort`.

## Also in this PR (drive-by cleanups)

- `check-migrations.ts`: drop the old single-file `migrations.ts` fallback — the per-version layout is on `main` (removed the matching WORKAROUNDS entry).
- Stale IPv4 prod notes updated → prod is full IPv6 (`listenHost=::1`, nginx dials `::1`): `apps/api`/`apps/game-server` WORKAROUNDS + `infra/README.md`.

## Verified

Two worktrees side-by-side (`pnpm dev` with only the documented env): distinct IPs, all services on default ports on their own IP, web 200, web→api proxying per instance, separate `bgs-*-dev` dbs. Allocator idempotent + reuses freed IPs. `svelte-check` / `tsc` clean.

## Follow-up work (not in this PR)

- **Ephemeral PR envs on the home minipc** (96 GB, idle): Tailscale mesh (minipc + coyo, no inbound ports on the home network), rootless Podman per env (game-server `npm install`s third-party engines — sandbox it), per-env `bgs-pr-<n>` dbs on a local Mongo. coyo nginx reverse-proxies `pr-<n>.boardgamers.space` → minipc over Tailscale (keeps Let's Encrypt + one public entry point).
- **`pr-preview.yml` workflow**: gated on `author_association: MEMBER` (or a `preview` label), builds + spins the env, comments the URL on the PR, tears down on close. Cap concurrent envs (~5).
- **Prod data for previews**: replicate, don't share — nightly sanitized `bgs` dump (strip user emails/sessions) shipped to the minipc over Tailscale; env dbs restored from that template. Never point PR code at the live `bgs`.
- **Phone/real-time scenario**: Tailscale on the phone → open the preview URL directly (works through coyo), or `tailscale serve` for a local dev instance.
- **Game-engine sandboxing** on the minipc: `apps/game-server` runs `npm install` + dynamically loads engines (`app/services/installer.ts`), so envs must be containers with no published ports except web, `no-new-privileges`, mem/CPU limits.

Scaleway k8s deliberately skipped — the minipc is strictly better hardware sitting idle.
