### PR TITLE
Preserve immutable SvelteKit chunks during deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,21 @@ jobs:
             # Build into a temp dir so the live build/ is never half-written.
             WEB_ADAPTER_OUT=build-new pnpm --filter @bgs/web build
 
+            # Keep immutable chunks from recent builds for ~30 days: clients with an
+            # already-loaded page still reference old hashed filenames, and deleting them
+            # breaks client-side navigation until a refresh. Files under _app/immutable are
+            # content-hashed, so a same-named carry-over is byte-identical. build-old (the
+            # pre-swap build) is copied first because it accumulated chunks from earlier
+            # deploys; cp -n never overwrites, so duplicates are skipped. cp -p preserves
+            # mtimes so the age-based pruning below measures from the chunk's first build,
+            # not its last copy.
+            for prev in apps/web/build-old apps/web/build; do
+              if [ -d \"$prev/client/_app/immutable\" ]; then
+                cp -prn \"$prev/client/_app/immutable/.\" apps/web/build-new/client/_app/immutable/
+              fi
+            done
+            find apps/web/build-new/client/_app/immutable -type f -mtime +30 -delete
+
             # Atomically swap the new build into place, then reload PM2.
             # PM2 runs index.js from cwd ./apps/web/build in cluster mode,
             # so reload picks up the new files with zero downtime.
@@ -62,6 +77,15 @@ jobs:
             # Nginx serves admin from dist/ directly (no PM2), so the swap
             # is the only protection against a half-written directory.
             ADMIN_ADAPTER_OUT=dist-new pnpm --filter @bgs/admin build
+
+            # Same immutable-chunk retention as the web app (nginx serves dist/ directly).
+            for prev in apps/admin/dist-old apps/admin/dist; do
+              if [ -d \"$prev/_app/immutable\" ]; then
+                cp -prn \"$prev/_app/immutable/.\" apps/admin/dist-new/_app/immutable/
+              fi
+            done
+            find apps/admin/dist-new/_app/immutable -type f -mtime +30 -delete
+
             rm -rf apps/admin/dist-old
             if [ -d apps/admin/dist ]; then mv apps/admin/dist apps/admin/dist-old; fi
             mv apps/admin/dist-new apps/admin/dist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,15 +6,15 @@ Guidance for AI agents (and humans) working in this monorepo.
 
 Boardgamers — an online board game platform. pnpm workspace, Node ≥ 24, ESM (`"type": "module"`).
 
-| Path               | What                                                                                             |
-| ------------------ | ------------------------------------------------------------------------------------------------ |
-| `apps/web`         | Player frontend (SvelteKit, Svelte 5)                                                            |
-| `apps/admin`       | Admin panel (SvelteKit, modern)                                                                  |
-| `apps/api`         | REST API (Koa + MongoDB)                                                                         |
-| `apps/game-server` | Game engine runner / gameplay API                                                                |
-| `apps/docs`        | Docs site                                                                                        |
-| `packages/models`  | Shared Zod schemas + Mongo collection definitions (`@bgs/models`)                                |
-| `packages/utils`   | Shared helpers (`@bgs/utils`)                                                                    |
+| Path               | What                                                              |
+| ------------------ | ----------------------------------------------------------------- |
+| `apps/web`         | Player frontend (SvelteKit, Svelte 5)                             |
+| `apps/admin`       | Admin panel (SvelteKit, modern)                                   |
+| `apps/api`         | REST API (Koa + MongoDB)                                          |
+| `apps/game-server` | Game engine runner / gameplay API                                 |
+| `apps/docs`        | Docs site                                                         |
+| `packages/models`  | Shared Zod schemas + Mongo collection definitions (`@bgs/models`) |
+| `packages/utils`   | Shared helpers (`@bgs/utils`)                                     |
 
 ## Comments
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Boardgamers — an online board game platform. pnpm workspace, Node ≥ 24, ESM 
 
 | Path               | What                                                                                             |
 | ------------------ | ------------------------------------------------------------------------------------------------ |
-| `apps/web`         | Player frontend (SvelteKit, **pinned to an ancient prerelease** — see `apps/web/WORKAROUNDS.md`) |
+| `apps/web`         | Player frontend (SvelteKit, Svelte 5)                                                            |
 | `apps/admin`       | Admin panel (SvelteKit, modern)                                                                  |
 | `apps/api`         | REST API (Koa + MongoDB)                                                                         |
 | `apps/game-server` | Game engine runner / gameplay API                                                                |

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -63,8 +63,13 @@ export const handle: Handle = async ({ event, resolve }) => {
 
 function backendUrl(override: string | undefined, defaultPort: number): string {
 	const raw = (override ?? import.meta.env.VITE_backend ?? "127.0.0.1").replace(/^https?:\/\//, "");
-	const [host, port] = raw.split(":");
-	const ip = host.includes(":") ? `[${host}]` : host; // bare IPv6
+	// Bare IPv6 (contains multiple colons, no brackets) has no port — a naive split(":")
+	// would shred it. Otherwise split host:port on the last colon only.
+	const isBareIpv6 = !raw.startsWith("[") && (raw.match(/:/g)?.length ?? 0) > 1;
+	const idx = raw.lastIndexOf(":");
+	const host = isBareIpv6 || idx === -1 ? raw : raw.slice(0, idx);
+	const port = isBareIpv6 || idx === -1 ? undefined : raw.slice(idx + 1);
+	const ip = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
 	return `http://${ip}:${port ?? defaultPort}`;
 }
 

--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -1,5 +1,20 @@
 import adapter from "@sveltejs/adapter-node";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+import { execSync } from "node:child_process";
+
+// Same release id as vite.config.ts. Used as the app version so stale clients can
+// reliably detect a deploy by comparing against /_app/version.json — with the default
+// (build timestamp), a cached old version.json can equal the served one and make
+// SvelteKit's "reload after failed chunk import" check report a false negative.
+const release =
+	process.env.APP_RELEASE ??
+	(() => {
+		try {
+			return execSync("git rev-parse --short HEAD").toString().trim();
+		} catch {
+			return Date.now().toString();
+		}
+	})();
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -11,6 +26,9 @@ const config = {
 			"@": "src",
 			"@cdk": "src/modules/cdk",
 		},
+		// No pollInterval: deploys preserve old chunks for 30 days (see deploy.yml), so
+		// already-open pages keep working client-side instead of needing a reload.
+		version: { name: release },
 	},
 };
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -6,12 +6,12 @@ Production runs on a single bare-metal server (**coyo**, Debian 12, 31 GB RAM, 9
 
 All apps run under PM2 as the `bgs` user, managed via `ecosystem.config.cjs` at the repo root.
 
-| PM2 name        | App                | Mode    | Notes                                          |
-| --------------- | ------------------ | ------- | ---------------------------------------------- |
-| `api`           | `apps/api`         | fork    | Koa REST API, `npm start`                      |
-| `game-server`   | `apps/game-server` | fork    | Game engine runner, `npm start`                |
-| `web`           | `apps/web`         | cluster | SvelteKit SSR, 2 instances                     |
-| `pm2-logrotate` | (module)           | fork    | Rotates PM2 logs at 10 MB, 30-day retain       |
+| PM2 name        | App                | Mode    | Notes                                    |
+| --------------- | ------------------ | ------- | ---------------------------------------- |
+| `api`           | `apps/api`         | fork    | Koa REST API, `npm start`                |
+| `game-server`   | `apps/game-server` | fork    | Game engine runner, `npm start`          |
+| `web`           | `apps/web`         | cluster | SvelteKit SSR, 2 instances               |
+| `pm2-logrotate` | (module)           | fork    | Rotates PM2 logs at 10 MB, 30-day retain |
 
 PM2 is managed as the `bgs` user (not root). Logs are in `~/.pm2/logs/`.
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -10,7 +10,7 @@ All apps run under PM2 as the `bgs` user, managed via `ecosystem.config.cjs` at 
 | --------------- | ------------------ | ------- | ---------------------------------------------- |
 | `api`           | `apps/api`         | fork    | Koa REST API, `npm start`                      |
 | `game-server`   | `apps/game-server` | fork    | Game engine runner, `npm start`                |
-| `web`           | `apps/web`         | cluster | SvelteKit SSR (pinned prerelease), 2 instances |
+| `web`           | `apps/web`         | cluster | SvelteKit SSR, 2 instances                     |
 | `pm2-logrotate` | (module)           | fork    | Rotates PM2 logs at 10 MB, 30-day retain       |
 
 PM2 is managed as the `bgs` user (not root). Logs are in `~/.pm2/logs/`.


### PR DESCRIPTION
Fix #83 

- keep chunks for 30 days
- use sveltekit built-in mechanism to SSR when chunk is missing (by specifying release name)